### PR TITLE
Refactor public key ingest to support OpenSSH keys

### DIFF
--- a/ossh_util.go
+++ b/ossh_util.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"crypto/x509"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -27,23 +26,21 @@ func publicKeyFile(file string) (ssh.AuthMethod, error) {
 	if err != nil {
 		return nil, err
 	}
-	p, rest := pem.Decode(buffer)
+	_, rest := pem.Decode(buffer)
 	if len(rest) > 0 {
 		return nil, errors.New("Failed to decode the key \"" + file + "\"")
 	}
-	pBlock := pem.Block{
-		Bytes:   buffer,
-		Type:    p.Type,
-		Headers: p.Headers,
-	}
-	if x509.IsEncryptedPEMBlock(&pBlock) {
-		key, err = ssh.ParsePrivateKeyWithPassphrase(buffer, readBytePasswordFromTerminal("SSH Passphrase:"))
-	} else {
-		key, err = ssh.ParsePrivateKey(buffer)
-	}
-	if err != nil {
+
+	if key, err = ssh.ParsePrivateKey(buffer); err != nil {
+		if err == err.(*ssh.PassphraseMissingError) {
+			if key, err = ssh.ParsePrivateKeyWithPassphrase(buffer, readBytePasswordFromTerminal("SSH Passphrase:")); err != nil {
+				return nil, err
+			}
+			return ssh.PublicKeys(key), nil
+		}
 		return nil, err
 	}
+
 	return ssh.PublicKeys(key), nil
 }
 


### PR DESCRIPTION
Support for encrypted OpenSSH keys was fixed in https://github.com/golang/crypto/commit/c9f3fb736b729628ec1e9c1a6b4313e883f452f9. This slightly refactors the publicKeyFile() method to:

1. Try parsing the public key normally
2. If this fails and it's not a PassphraseMissing Error, return nil, err
2. If this fails and it *is*, prompt the user for a passphrase and then try to parse it again
3. If *this* fails, return nil, err